### PR TITLE
fix: force push to avoid errors in deploy tests

### DIFF
--- a/.circleci/test-deploy.yml
+++ b/.circleci/test-deploy.yml
@@ -20,6 +20,7 @@ jobs:
           fingerprints:
             - "$SSH_KEY_FINGERPRINT"
       - dokku/deploy:
+          git-push-flags: --force
           git-remote-url: ssh://dokku@dokku.com:22/ci-orb-test
 
 workflows:


### PR DESCRIPTION
Due to repo history changes, sometimes the github repo and remote get out of sync, so this is necessary for us to pass tests.