### PR TITLE
docs: add more varied examples for users

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,13 +15,12 @@ The private key for the dokku user you wish to use for deploys will need to be a
 ```yaml
 ---
 version: 2.1
-
 orbs:
-  dokku: dokku/dokku@0.3.0
-
+  dokku: dokku/dokku@0.1.0
 workflows:
-  build-test-deploy:
+  deploy:
     jobs:
+      - checkout
       - add_ssh_keys:
           fingerprints:
             - "$SSH_KEY_FINGERPRINT"
@@ -29,53 +28,7 @@ workflows:
           git-remote-url: ssh://dokku@dokku.myhost.ca:22/appname
 ```
 
-See further examples and documentation can be found on the [CircleCI Orb Registry Page](https://circleci.com/orbs/registry/orb/dokku/dokku).
-
-### IP whitelisting
-
-Your dokku host may be behind a firewall, in which case you might want to whitelist the IP of the builder prior to using the commands exposed through this orb. Though this orb does not include any commands or jobs specific to IP whitelisting, this can be accomplished using other third party orbs. Consider the example below for inspiration.
-
-```yaml
----
-version: 2.1
-
-orbs:
-  dokku: dokku/dokku@0.3.0
-  ip-address-helper: dokku/ip-address-helper@1.0.0
-
-jobs:
-  deploy-behind-firewall:
-    executor: dokku/default
-    resource_class: small
-    steps:
-      - checkout
-      # See implementation of this orb - it is just a convenient way of grabbing the externally facing IP address of the builder
-      - ip-address-helper/set-env-var
-      - run:
-          name: Whitelist the IP
-          command: |
-            # TODO use an API to whitelist IP - e.g AWS, DigitalOcean, Scaleway etc have API's for adding the IP to a security group.
-
-      - add_ssh_keys:
-          fingerprints:
-            - "SO:ME:FIN:G:ER:PR:IN:T"
-
-      - dokku/deploy:
-          git-remote-url: ssh://dokku@dokku.myhost.ca:22/appname
-        
-      - run:
-          name: Remove the IP
-          command: |
-            # TODO use an API to remove the IP
-          when: always # this line ensures this will still be run even if the job fails for some reason
-
-workflows:
-  deploy:
-    jobs:
-      - deploy
-```
-
-**Note:** Several caveats exist with the above approach, including but not limited to the fact that docker jobs are not likely to have exclusive use of an external IP address and in the unlikely case of infrastructure failure, an IP could fail to be removed from your whitelist. If security is paramount [CircleCI's Runner](https://circleci.com/docs/2.0/runner-overview/#introduction) is likely a better a fit.
+See more examples on the [CircleCI Orb Registry Page](https://circleci.com/orbs/registry/orb/dokku/dokku).
 
 ## Resources
 

--- a/src/examples/build-and-deploy.yaml
+++ b/src/examples/build-and-deploy.yaml
@@ -1,0 +1,30 @@
+---
+description: >
+  Builds a docker image in CI, pushes the image to the remote Docker Hub
+  repository, and then notifies Dokku to deploy the built image.
+
+usage:
+  version: 2.1
+  orbs:
+    dokku: dokku/dokku@0.1.0
+  workflows:
+    deploy:
+      jobs:
+        - checkout
+        - add_ssh_keys:
+            fingerprints:
+              - "$SSH_KEY_FINGERPRINT"
+        - run:
+            name: build and push image
+            command: |
+              # build the image
+              docker build -t "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1" .
+
+              # login to docker hub
+              echo "$DOCKERHUB_TOKEN" | docker login --username "$DOCKERHUB_USERNAME" --password-stdin
+
+              # push the image
+              docker push "$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1"
+        - dokku/deploy:
+            deploy-docker-image: $CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME:$CIRCLE_SHA1
+            git-remote-url: ssh://dokku@dokku.myhost.ca:22/appname

--- a/src/examples/custom-deploy-branch.yml
+++ b/src/examples/custom-deploy-branch.yml
@@ -1,0 +1,20 @@
+---
+description: >
+  Certain Dokku installations may use custom deploy branches other than
+  `master`. In the following example, we push to the `develop` branch.
+
+usage:
+  version: 2.1
+  orbs:
+    dokku: dokku/dokku@0.1.0
+  workflows:
+    deploy:
+      jobs:
+        - checkout
+        - add_ssh_keys:
+            fingerprints:
+              - "$SSH_KEY_FINGERPRINT"
+        - dokku/deploy:
+            # specify the `main` branch as the remote branch to push to
+            branch: main
+            git-remote-url: ssh://dokku@dokku.myhost.ca:22/appname

--- a/src/examples/force-push.yml
+++ b/src/examples/force-push.yml
@@ -1,0 +1,20 @@
+---
+description: >
+  If the remote app has been previously pushed manually from a location other
+  than CI, it may be necessary to enable force pushing to avoid git errors.
+
+usage:
+  version: 2.1
+  orbs:
+    dokku: dokku/dokku@0.1.0
+  workflows:
+    deploy:
+      jobs:
+        - checkout
+        - add_ssh_keys:
+            fingerprints:
+              - "$SSH_KEY_FINGERPRINT"
+        - dokku/deploy:
+            git-remote-url: ssh://dokku@dokku.myhost.ca:22/appname
+            # specify `--force` as a flag for git pushes
+            git-push-flags: '--force'

--- a/src/examples/ip-whitelisting.yml
+++ b/src/examples/ip-whitelisting.yml
@@ -1,0 +1,36 @@
+---
+description: >
+  Your dokku host may be behind a firewall, in which case you might want to
+  whitelist the IP of the builder prior to using the commands exposed through
+  this orb. Though this orb does not include any commands or jobs specific to
+  IP whitelisting, this can be accomplished using other third party orbs.
+  Consider the example below for inspiration.
+
+usage:
+  version: 2.1
+  orbs:
+    dokku: dokku/dokku@0.3.0
+    ip-address-helper: dokku/ip-address-helper@1.0.0
+  workflows:
+    deploy:
+      jobs:
+        - checkout
+        # See implementation of this orb - it is just a convenient way of grabbing the externally facing IP address of the builder
+        - ip-address-helper/set-env-var
+        - run:
+            name: Whitelist the IP
+            command: |
+              # TODO use an API to whitelist IP - e.g AWS, DigitalOcean, Scaleway etc have API's for adding the IP to a security group.
+
+        - add_ssh_keys:
+            fingerprints:
+              - "SO:ME:FIN:G:ER:PR:IN:T"
+
+        - dokku/deploy:
+            git-remote-url: ssh://dokku@dokku.myhost.ca:22/appname
+
+        - run:
+            name: Remove the IP
+            command: |
+              # TODO use an API to remove the IP
+            when: always # this line ensures this will still be run even if the job fails for some reason

--- a/src/examples/simple.yml
+++ b/src/examples/simple.yml
@@ -5,10 +5,11 @@ description: >
 usage:
   version: 2.1
   orbs:
-    dokku: dokku/dokku@0.3.0
+    dokku: dokku/dokku@0.1.0
   workflows:
     deploy:
       jobs:
+        - checkout
         - add_ssh_keys:
             fingerprints:
               - "$SSH_KEY_FINGERPRINT"

--- a/src/examples/specify-ssh-host-key.yaml
+++ b/src/examples/specify-ssh-host-key.yaml
@@ -1,0 +1,23 @@
+---
+description: >
+  By default, this action will scan the host for it's SSH host key and use that
+  value directly. This may not be desirable for security compliance reasons.
+
+  The `SSH_HOST_KEY` value can be retrieved by calling
+  `ssh-keyscan -t rsa $HOST`, where `$HOST` is the Dokku server's hostname.
+
+usage:
+  version: 2.1
+  orbs:
+    dokku: dokku/dokku@0.1.0
+  workflows:
+    deploy:
+      jobs:
+        - checkout
+        - add_ssh_keys:
+            fingerprints:
+              - "$SSH_KEY_FINGERPRINT"
+        - dokku/deploy:
+            git-remote-url: ssh://dokku@dokku.myhost.ca:22/appname
+            # specify an alternative ssh host key
+            ssh-host-key: $SOME_SSH_HOST_KEY

--- a/src/examples/verbose-logging.yml
+++ b/src/examples/verbose-logging.yml
@@ -1,0 +1,23 @@
+---
+description: >
+  Verbose client-side logging may be enabled with this method. Note that this
+  does not enable trace mode on the deploy, and simply tells the `git` client
+  to enable verbose log output
+
+usage:
+  version: 2.1
+  orbs:
+    dokku: dokku/dokku@0.1.0
+  workflows:
+    deploy:
+      jobs:
+        - checkout
+        - add_ssh_keys:
+            fingerprints:
+              - "$SSH_KEY_FINGERPRINT"
+        - dokku/deploy:
+            git-remote-url: ssh://dokku@dokku.myhost.ca:22/appname
+            # enable verbose git output
+            git-push-flags: '-vvv'
+            # enable verbose ssh output
+            git-ssh-command: 'ssh -vvv'


### PR DESCRIPTION
This moves all examples into the orb documentation.