### PR TITLE
Fix typo in executor config

### DIFF
--- a/src/executors/default.yml
+++ b/src/executors/default.yml
@@ -4,7 +4,7 @@ description: >
   tools to interact with a remote Dokku host
 
 docker:
-  - image: dokku/ci-docker-image:<<parameters.tag>>'
+  - image: dokku/ci-docker-image:<<parameters.tag>>
 
 parameters:
   tag:


### PR DESCRIPTION
This typo leads to error when I try to use it in circle ci

circleci config:
```yml
version: 2.1

orbs:
  dokku: dokku/dokku@0.2.0

jobs:
  deploy:
    executor: dokku/default
    steps:
      - checkout
      - dokku/deploy:
          git-remote-url: 'ssh://dokku@dokku.me'

workflows:
  deploy:
    jobs:
      - deploy
```

error:
```
Starting container dokku/ci-docker-image:0.2.1'
  image cache not found on this host, downloading dokku/ci-docker-image:0.2.1'

invalid reference format
```